### PR TITLE
fix: py3 AttributeError decode

### DIFF
--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -99,7 +99,7 @@ class RedisWrapper(redis.Redis):
 
 		except redis.exceptions.ConnectionError:
 			regex = re.compile(cstr(key).replace("|", "\|").replace("*", "[\w]*"))
-			return [k for k in list(frappe.local.cache) if regex.match(k.decode())]
+			return [k for k in list(frappe.local.cache) if regex.match(cstr(k))]
 
 	def delete_keys(self, key):
 		"""Delete keys with wildcard `*`."""


### PR DESCRIPTION
in python3: AttributeError: 'str' object has no attribute 'decode' in line 102
therefore use cstr instead of decode
